### PR TITLE
Allow disabling repo installation

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 journalbeat_repo: "https://copr-be.cloud.fedoraproject.org/results/bcdonadio/journalbeat/epel-7-$basearch/"
 journalbeat_repokey: "https://copr-be.cloud.fedoraproject.org/results/bcdonadio/journalbeat/pubkey.gpg"
+journalbeat_repo_enable: true
 
 # Use the following variables to simplified setup
 journalbeat_elasticsearch: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,7 @@
     description: "Journalbeat repository"
     baseurl: "{{ journalbeat_repo }}"
     gpgkey: "{{ journalbeat_repokey }}"
+  when: journalbeat_repo_enable
 
 - name: install journalbeat
   package:


### PR DESCRIPTION
This makes it easy to use the role in environments where the package sources are managed with a central RPM repository management tool (like. spacewalk and others).