### PR TITLE
Add config file path variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,8 @@
 journalbeat_repo: "https://copr-be.cloud.fedoraproject.org/results/bcdonadio/journalbeat/epel-7-$basearch/"
 journalbeat_repokey: "https://copr-be.cloud.fedoraproject.org/results/bcdonadio/journalbeat/pubkey.gpg"
 
+journalbeat_config_dest: /etc/journalbeat.yml
+
 # Use the following variables to simplified setup
 journalbeat_elasticsearch: false
 journalbeat_logstash: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,7 +17,7 @@
     dest: "{{ item.dest }}"
   with_items:
     - src: "journalbeat.yml.j2"
-      dest: "/etc/journalbeat.yml"
+      dest: "{{ journalbeat_config_dest }}"
   notify:
     - restart journalbeat
 


### PR DESCRIPTION
You can use `journalbeat_config_dest` to configure the exact location
of `journalbeat.yml`.